### PR TITLE
Remove script tags from Highcharts media function

### DIFF
--- a/templates/includes/highchart_media.html
+++ b/templates/includes/highchart_media.html
@@ -1,5 +1,3 @@
-
-<script>
 $(function(){
   Highcharts.setOptions({{chart.setoption|safe}});
   var option = {{chart.option|safe}};
@@ -11,4 +9,3 @@ $(function(){
     chart.addSeries(data[ix]);
   }
 });
-</script>


### PR DESCRIPTION
Hi @henhuy,

as spoken a pull request to remove the script tags from the Highcharts function in templates/includes/highchart_media.html.

I did this pull request on master, because dev is a few commits behind. 