### PR TITLE
Allow a new user to not encounter error on their first deploy

### DIFF
--- a/.config/config.cfg
+++ b/.config/config.cfg
@@ -1,0 +1,33 @@
+# Template configuration file for WAM
+#
+# variable names surrounded by < and > should be changed by the user.
+# See https://wam.readthedocs.io/en/latest/getting_started.html#postgresql-setup
+
+[WAM]
+    DEBUG=True
+    ALLOWED_HOSTS=127.0.0.1
+    SECRET_KEY=<secret_key>
+    DJANGO_DB=DEFAULT
+
+[DATABASES]
+	[[DEFAULT]]
+        ENGINE = django.contrib.gis.db.backends.postgis
+        HOST = localhost
+        PORT = 5432
+        NAME = <wam_database>
+        USER = <wam_admin>
+        PASSWORD = <wam_test>
+    [[LOCAL]]
+        ENGINE = postgresql
+        HOST = localhost
+        PORT = 5432
+        NAME = <wam_database>
+        USER = <wam_admin>
+        PASSWORD = <wam_test>
+
+[CELERY]
+    HOST = localhost
+    PORT = 5672
+    USER = <user>
+    PASSWORD = <password>
+    VHOST = <vhost>

--- a/doc/compile_doc_locally.rst
+++ b/doc/compile_doc_locally.rst
@@ -1,0 +1,25 @@
+Edit documentation
+==================
+
+Idea
+----
+
+If a user want to improve the documentation, here is how to produce html files locally before
+pushing the changes to the repository.
+
+Getting Started
+---------------
+
+First, you have to install the sphinx package:
+
+.. code:: bash
+
+    pip install sphinx
+
+Then, from the root of the WAM repository, run the following command to compile your documentation:
+
+.. code:: bash
+
+    make html
+
+The html file will be available under doc/_build/html/index.html.

--- a/doc/continuous_integration.rst
+++ b/doc/continuous_integration.rst
@@ -1,0 +1,2 @@
+Continuous integration
+======================

--- a/doc/contributor_guide.rst
+++ b/doc/contributor_guide.rst
@@ -1,0 +1,20 @@
+Contribute
+==================
+
+.. contents::
+   :depth: 3
+
+Idea
+----
+
+If a user want to improve the existing code, here is a description of the workflow and coding
+practices we would like to enable.
+
+Getting Started
+---------------
+
+Workflow
+^^^^^^^^
+
+Code Linting
+^^^^^^^^^^^^

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -1,9 +1,10 @@
+Introduction
+============
 
-Getting started
-===============
 
 .. contents::
-   :depth: 2
+   :depth: 3
+
 
 Idea
 ----
@@ -11,6 +12,8 @@ Idea
 WebAppMap-Server [WAM] provides a basic and expandable Django_ infrastructure to easily add applications.
 
 .. _Django: https://www.djangoproject.com/
+
+.. _prerequisites:
 
 Prerequisites
 -------------
@@ -25,9 +28,10 @@ Prerequisites
 postgresql setup
 ^^^^^^^^^^^^^^^^
 
-The following instructions are for Ubuntu and inpired from `here`__
-First create a user name (here *wam_admin* is used for the *USER* field of the config file
-:ref:`configuration`)
+The following instructions are for Ubuntu and inspired from here_.
+
+First, create a user name (here, *wam_admin* is used for the *USER* field of the config
+file :ref:`configuration`)
 
 .. code:: bash
 
@@ -48,7 +52,7 @@ There, change the password for the user *wam_admin*
 Enter the same password you will use under the *PASSWORD* field in the config file
 (:ref:`configuration`) and exit the shell with `\\q`
 
-Create the database you will use under the *NAME* field in the config file
+Then, create the database you will use under the *NAME* field in the config file
 (:ref:`configuration`)
 
 .. code:: bash
@@ -67,12 +71,12 @@ This can be stopped using the command
 
     sudo service postgresql stop
 
-__ https://help.ubuntu.com/community/PostgreSQL
+.. _here: https://help.ubuntu.com/community/PostgreSQL
 
 
 .. _postgis:
 
-Postgis setup
+postgis setup
 ^^^^^^^^^^^^^
 
 For Ubuntu:
@@ -106,8 +110,17 @@ Other users have to setup their own message broker
 .. _RabbitMQ: https://www.rabbitmq.com/
 .. _RAbbitMQDocker: https://hub.docker.com/_/rabbitmq/
 
+
+.. _getting_started:
+
+Getting Started
+---------------
+
+
+.. _setup:
+
 Setup
------
+^^^^^
 
 Clone repository from github via:
 
@@ -129,15 +142,45 @@ Requirements and configuration of an application can be found at :ref:`app_setti
 .. _configuration:
 
 Configuration
--------------
+^^^^^^^^^^^^^
 
 The WAM-Server can be configured as follows.
+
+
+.. _environment:
+
+Environment Variables
+^^^^^^^^^^^^^^^^^^^^^
+
+WAM-Server needs at least the following environment variables:
+
+- WAM_CONFIG_PATH: full path to the configuration file (see :ref:`configuration_file` for the file content)
+
+- WAM_APPS: Apps which shall be loaded within *INSTALLED_APPS*. Additionally, individual app settings are loaded (see :ref:`app_settings`).
+
+On Ubuntu, one can add them to the ``bashrc`` file, so that they are loaded automatically :
+
+.. code:: bash
+
+  nano ~/.bashrc
+
+then add the following two lines
+
+.. code:: bash
+
+   export WAM_CONFIG_PATH=<path to your WAM repo>/.config/config.cfg
+   export WAM_APPS=<name of wam app 1>,<name of wam app 2>
+
+.. _configobj: https://configobj.readthedocs.io/en/latest/configobj.html
+
+
+.. _configuration_file:
 
 Configuration file
 ^^^^^^^^^^^^^^^^^^
 
-Configuration file from path given by *CONFIG_PATH* is loaded within *settings.py*. The file is
-read in using python's configobj_ package.
+Configuration file located under the path given by *WAM_CONFIG_PATH* is loaded within *settings
+.py*. The file is read in using python's configobj_ package.
 The file should contain following sections:
 
 - *[WAM]*: general config for the WAM-Server,
@@ -151,22 +194,65 @@ See minimal example config_file_:
 
 .. _config_file: _static/config.cfg
 
-.. _environment:
+Note: the indent level is important in the configuration file. Keywords are specified within ``[]``, they are analog to the
+key in a python ``dict``. The nesting level of a keyword depends on the number of square brackets.
 
-Environment Variables
-^^^^^^^^^^^^^^^^^^^^^
 
-WAM-Server needs at least the following environment variables:
+.. _server_deploy:
 
-- CONFIG_PATH: Path to configuration file (mainly includes database configurations, see :ref:`configuration`)
-- WAM_APPS: Apps which shall be loaded within *INSTALLED_APPS*. Additionally, individual app settings are loaded (see :ref:`app_settings`).
+Deploying server without apps
+-----------------------------
 
-.. _configobj: https://configobj.readthedocs.io/en/latest/configobj.html
+Even without adding apps into WAM, you can follow these steps to deploy the WAM server locally.
+
+Make sure the postgresql_ service is running
+
+.. code:: bash
+
+    sudo service postgresql start
+
+Then, run the following commands
+
+.. code:: bash
+
+    python manage.py makemigrations
+
+.. code:: bash
+
+    python manage.py migrate
+
+.. code:: bash
+
+    python manage.py createsuperuser
+
+After the last command, follow the instructions inside the terminal and use the same values for
+user and password as the *USER* and *PASSWORD* fields of the :ref:`configuration_file`.
+
+Finally access to the WAM server with
+
+.. code:: bash
+
+    python manage.py runserver
+
+.. _example_app_settings:
+
+Example app
+^^^^^^^^^^^
+
+From the root level of the WAM repository, you can clone the app *WAM_APP_stemp_mv* with
+
+.. code:: bash
+
+    git clone https://github.com/rl-institut/WAM_APP_stemp_mv.git
+
+For the time being you have to rename the app folder *stemp* and set your environment variable
+*WAM_APPS* to *stemp*
+
 
 .. _app_settings:
 
-App Setup
----------
+Deploying server with custom apps
+---------------------------------
 
 Requirements:
 
@@ -185,52 +271,10 @@ To install the required packages for each app run
 
     python install_requirements.py
 
-from the root level of the WAM repository.
+from the root level of the WAM repository. Then follow the procedure described under :ref:`server_deploy`
 
 
-Make sure the postgresql_ service is running
-
-.. code:: bash
-
-    sudo service postgresql start
-
-Then run the following commands
-
-.. code:: bash
-
-    python manage.py makemigrations
-
-.. code:: bash
-
-    python manage.py migrate
-
-.. code:: bash
-
-    python manage.py createsuperuser
-
-upon the last command follow the instructions inside the terminal and use the same values for
-user and password as the *USER* and *PASSWORD* fields of the config file
-:ref:`configuration`.
-
-Finally access to the WAM server by running
-
-.. code:: bash
-
-    python manage.py runserver
-
-
-Example app:
-
-From the root level of the WAM repository, you can clone the app *WAM_APP_stemp_mv* with
-
-.. code:: bash
-
-    git clone https://github.com/rl-institut/WAM_APP_stemp_mv.git
-
-For the time being you have to rename the app folder *stemp* and set your environment variable
-*WAM_APPS* to *stemp*
-
-.. _celery_setup:
+.. _use_celery:
 
 Celery
 ------
@@ -239,7 +283,7 @@ Celery_ is included in WAM. In order to use celery in an app, follow the :ref:`s
 
 .. _Celery: http://docs.celeryproject.org/en/latest/
 
-.. _setup:
+.. _celery_setup:
 
 Setup
 ^^^^^

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,6 +13,9 @@ Welcome to WAM-Server's documentation!
    getting_started
    helpers
    api_changes
+   contributor_guide
+   continuous_integration
+   compile_doc_locally
 
 
 Indices and tables

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     container_name: wam
     command: /bin/bash -c "source activate django && cd /code && gunicorn --bind 0.0.0.0:5000 wam.wsgi:application"
     environment:
-      CONFIG_PATH: /config/config.cfg
+      WAM_CONFIG_PATH: /config/config.cfg
     volumes:
     - ../config:/config
     networks:
@@ -24,7 +24,7 @@ services:
     container_name: celery
     command: /bin/bash -c "source activate django && cd /code && celery -A wam -Q wam_queue worker -l info"
     environment:
-      CONFIG_PATH: /config/config.cfg
+      WAM_CONFIG_PATH: /config/config.cfg
     volumes:
     - ../config:/config
     networks:

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: wam-django
+name: django
 dependencies:
 - python=3.6
 - pip:

--- a/environment.yml
+++ b/environment.yml
@@ -1,16 +1,5 @@
-name: django
+name: wam-django
 dependencies:
 - python=3.6
 - pip:
-  - django
-  - gunicorn
-  - pandas
-  - whitenoise
-  - "git+https://github.com/celery/celery.git"
-  - configobj
-  - django-markdownx
-  - django-crispy-forms
-  - psycopg2-binary
-  - jmespath
-  - "git+https://github.com/openego/oedialect"
-  - "git+https://github.com/henhuy/python-highcharts.git"
+   - -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django
+jmespath
 gunicorn
 pandas
 whitenoise

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+django
+gunicorn
+pandas
+whitenoise
+celery
+configobj
+django-markdownx
+django-crispy-forms
+psycopg2-binary
+git+https://github.com/openego/oedialect

--- a/wam/settings.py
+++ b/wam/settings.py
@@ -15,7 +15,7 @@ import importlib
 import logging
 from configobj import ConfigObj
 
-config = ConfigObj(os.environ['CONFIG_PATH'])
+config = ConfigObj(os.environ['WAM_CONFIG_PATH'])
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))

--- a/wam/settings.py
+++ b/wam/settings.py
@@ -15,7 +15,14 @@ import importlib
 import logging
 from configobj import ConfigObj
 
-config = ConfigObj(os.environ['WAM_CONFIG_PATH'])
+config_file_path = os.environ.get('WAM_CONFIG_PATH')
+
+if config_file_path is None:
+    raise KeyError(
+        'Please add WAM_CONFIG_PATH as an environment variable, see '
+        'https://wam.readthedocs.io/en/latest/getting_started.html#environment-variables'
+    )
+config = ConfigObj(config_file_path)
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -35,7 +42,20 @@ logging.getLogger().setLevel(logging_level)
 ALLOWED_HOSTS = config['WAM'].as_list('ALLOWED_HOSTS')
 
 # Additional apps are loaded from environment variable
-WAM_APPS = os.environ['WAM_APPS'].split(',')
+WAM_APPS = os.environ.get('WAM_APPS')
+
+if WAM_APPS is None:
+    raise KeyError(
+        'Please add WAM_APPS as an environment variable, see '
+        'https://wam.readthedocs.io/en/latest/getting_started.html#environment-variables'
+    )
+
+if WAM_APPS == '':
+    # The environment variable exists but no apps are defined
+    WAM_APPS = []
+else:
+    # Apps name are retrieved
+    WAM_APPS = WAM_APPS.split(',')
 
 APP_LABELS = {
     app: ConfigObj(os.path.join(BASE_DIR, app, 'labels.cfg'))


### PR DESCRIPTION
- Create a separate `requirements.txt` file and include it in `environment.yml`.
- Improve the documentation steps and clarity for a fresh first install.
- Make sure one can at least execute `python manage.py runserver` and see the WAM welcome page, even if no apps are provided (i.e. if `WAM_APPS` environment variable is set to an empty string).
- Provide a template for the config file location.
- Change environment variable name `CONFIG_PATH` to `WAM_CONFIG_PATH`.