### PR TITLE
allow to force new user session

### DIFF
--- a/user_sessions/sessions.py
+++ b/user_sessions/sessions.py
@@ -6,8 +6,8 @@ class SessionData():
     def __init__(self):
         self.sessions = defaultdict(dict)
 
-    def start_session(self, request, session_obj):
-        if request.session.session_key is None:
+    def start_session(self, request, session_obj, force_new_session=False):
+        if request.session.session_key is None or force_new_session:
             request.session.create()
         app = get_app_from_request(request)
         if request.session.session_key not in self.sessions[app]:


### PR DESCRIPTION
in [SessionData.start_session()](https://github.com/rl-institut/WAM/blob/features/allow-force-new-session/user_sessions/sessions.py#L9)
This won't break the API as it uses an optional arg `force_new_session` which is False by default.

Needed for app stemp abw to force new session on page reload (cf. https://github.com/rl-institut/WAM_APP_stemp_abw/issues/43).

**EDIT:** Forcing a new session will prevent parallel usage of other apps as it deletes all session data of all apps.