### PR TITLE
Features/info button custom id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections
 - continuous integration with TravisCI (`.travis.yml`)
 - linting tests and their config files (`.pylintrc` and `.flake8`)
 - tests/ folder
+- support custom id in InfoButton widget 
 
 ### Changed
 - fix flake8 and pylint errors

--- a/utils/widgets.py
+++ b/utils/widgets.py
@@ -52,7 +52,7 @@ class InfoButton(CustomWidget):
             ionicon_type: str = 'ion-information-circled',
             ionicon_size: str = 'small',
             ionicon_color: str = None,
-            info_id = None
+            info_id: str = None
     ):
         """
 

--- a/utils/widgets.py
+++ b/utils/widgets.py
@@ -51,7 +51,8 @@ class InfoButton(CustomWidget):
             is_markdown: bool = False,
             ionicon_type: str = 'ion-information-circled',
             ionicon_size: str = 'small',
-            ionicon_color: str = None
+            ionicon_color: str = None,
+            info_id = None
     ):
         """
 
@@ -71,13 +72,21 @@ class InfoButton(CustomWidget):
             xxlarge
         ionicon_color : str
             Sets color of icon in hex color code, e.g. '#ff0000'
+        info_id : str
+            Optional. If provided, the reveal div id will be set to this value,
+            prepended by "info_". By default, a counter is used which results
+            in ids "info_0", "info_1" etc.
         """
-        self.id = next(self.counter)
         self.text = markdown(text) if is_markdown else text
         self.tooltip = tooltip
         self.ionicon_type = ionicon_type
         self.ionicon_size = ionicon_size
         self.ionicon_color = ionicon_color
+
+        if info_id is not None and isinstance(info_id, str):
+            self.id = info_id
+        else:
+            self.id = next(self.counter)
 
     def get_context(self):
         return {


### PR DESCRIPTION
Adds support for custom id in InfoButton widget with new arg `info_id`.
- If provided, the reveal div id will be set to this value, prepended by "info_".
- If not provided, a counter is used which results in ids "info_0", "info_1" etc. (as before)

This is useful e.g. to open the reveal with another JS function which requires a well-defined id.