### PR TITLE
Session errors are logged

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Here is a template for new release sections
 - continuous integration with TravisCI (`.travis.yml`)
 - linting tests and their config files (`.pylintrc` and `.flake8`)
 - tests/ folder
+- session error logging
 
 ### Changed
 - fix flake8 and pylint errors

--- a/user_sessions/utils.py
+++ b/user_sessions/utils.py
@@ -40,7 +40,7 @@ def check_session(func):
 
 def log_session_error(request):
     app = get_app_from_request(request)
-    logging.error(
+    err_msg = (
         f'Session error for app "{app}":\n'
         f'Session-Key: {request.session.session_key}\n'
         f'Current session data:\n' +
@@ -48,3 +48,4 @@ def log_session_error(request):
             [f'{k}: {str(v)}' for k, v in SESSION_DATA.sessions[app].items()]
         )
     )
+    logging.error(err_msg)


### PR DESCRIPTION
I need more information on session errors to debug my code.
Session errors are now logged in format:

Session error for app "appname":
Session-Key: current session key
Current session data:
session key: str-output of app-related UserSession

**Example for stemp app:**
Session error for app "stemp":
Session-Key: None
Current session data:
v3le6kj6hinj1cimdx72x80z4gyhm287: Scenarios: gas,oil,woodchip,pv_heatpump, Demand-Type: 0, Demand-ID: 303, District: {}
hlms88f1lyim1q47q3m6jj29fkxq9iir: Scenarios: , Demand-Type: 0, Demand-ID: 304, District: {}

See https://github.com/rl-institut/WAM_APP_stemp_mv/blob/87c6f4e20a75e2598d954c154bfda5a0eca1c47e/user_data.py#L142 for example of str-representation of UserSession