### PR TITLE
Features/add custom 404 and 500 pages

### DIFF
--- a/static/foundation/css/app.css
+++ b/static/foundation/css/app.css
@@ -8,6 +8,9 @@
 .l-bg-color--light {
   background-color: #D8E2ED; }
 
+.l-bg-color--error {
+  background-color: #F2994A; }
+
 a {
   font-weight: 700; }
 

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,0 +1,61 @@
+
+{% extends 'base.html' %}
+
+{% load static %}
+
+{% block content %}
+<div class="u-vh--100">
+
+  <main>
+
+    <section class="grid-x l-bg-color hp-hero">
+      <div class="cell u-text--center">
+        <img src="{% static '/img/logos/WAM_logo_w.png' %}" alt="Logo WAM" class="hp_wam_img">
+      </div>
+    </section>
+
+    <section class="grid-x align-center l-bg-color--error hp-features">
+      <div class="cell large-10">
+        <div class="grid-x align-center">
+          <h2><i class='icon ion-alert-circled icon--large'></i> {{ err_text }}</h2>
+        </div>
+      </div>
+    </section>
+
+  </main>
+
+
+  <footer class="footer-hp l-bg-color--w">
+    <div class="grid-x">
+
+      <div class="cell footer-hp__logo">
+        <ul>
+          <li>
+            <a href="{% url 'index' %}" rel=”noopener” title="WAM-Startseite">
+	            <img class="footer-hp__logo-wam" src="{% static '/img/logos/WAM_logo.png' %}" alt="Logo WAM">
+            </a>
+          </li>
+          <li>
+            <a href="https://reiner-lemoine-institut.de/" target="_blank" rel=”noopener noreferrer” title="Reiner Lemoine Institut">
+              <img class="footer-hp__logo-rli" src="{% static 'img/rli_logo.png' %}" alt="Logo Reiner Lemoine Institut">
+            </a>
+          </li>
+        </ul>
+      </div>
+
+      <div class="cell medium-10 medium-offset-1">
+        <ul class="u-text--center" id="footer-links">
+          <li><a class="anchor-text--dark" href="{% url 'contact' %}">Kontakt</a></li>
+          <li><a class="anchor-text--dark" href="{% url 'impressum' %}">Impressum</a></li>
+          <li><a class="anchor-text--dark" href="{% url 'privacy' %}">Datenschutz</a></li>
+          <li class="hide-for-small-only">
+            <p class="u-no-margin">&copy; Reiner Lemoine Institut gGmbH</p>
+          </li>
+        </ul>
+      </div>
+
+    </div>
+  </footer>
+
+</div>
+{% endblock %}

--- a/wam/urls.py
+++ b/wam/urls.py
@@ -49,3 +49,7 @@ for app_name in WAM_APPS:
         include(app_name + '.urls', namespace=app_name)
     )
     urlpatterns.append(app_url)
+
+# error handlers (work in non-debug mode only)
+handler404 = views.WAM404View.as_view()
+handler500 = views.WAM500View.as_view()

--- a/wam/urls.py
+++ b/wam/urls.py
@@ -26,7 +26,7 @@ from meta.views import AppListView, AssumptionsView
 
 
 urlpatterns = [
-    path('', views.IndexView.as_view()),
+    path('', views.IndexView.as_view(), name='index'),
     path('contact/', views.ContactView.as_view(), name='contact'),
     path('privacy/', views.PrivacyView.as_view(), name='privacy'),
     path('impressum/', views.ImpressumView.as_view(), name='impressum'),

--- a/wam/views.py
+++ b/wam/views.py
@@ -68,3 +68,24 @@ class IndexView(TemplateView):
     def get(self, request, *args, **kwargs):
         context = self.get_context_data()
         return self.render_to_response(context)
+
+
+class WAMErrorPage(TemplateView):
+    """A custom error page template"""
+    template_name = 'error.html'
+    err_text = 'Es ist ein Fehler aufgetreten'
+
+    def get_context_data(self, **kwargs):
+        context = super(WAMErrorPage, self).get_context_data()
+        context['err_text'] = self.err_text
+        return context
+
+
+class WAM404View(WAMErrorPage):
+    """A custom 404 page"""
+    err_text = 'Die Seite wurde leider nicht gefunden'
+
+
+class WAM500View(WAMErrorPage):
+    """A custom 500 page"""
+    err_text = 'Es ist ein Server-Fehler aufgetreten'


### PR DESCRIPTION
Adds custom 404 (page not found) and 500 (internal server error) pages to WAM. Both use a common generic error View which can be easily extended.

Django's [default error views](https://docs.djangoproject.com/en/2.1/topics/http/views/#customizing-error-views) are overridden by custom ones.
**Note: The override works in non-debug mode only!**
You can add
```
urlpatterns = [
    ...,
    path('404/', views.WAM404View.as_view()),
    path('500/', views.WAM500View.as_view()),
]
```
to wam/urls.py to test the pages.

Preview:
![wam_404_page](https://user-images.githubusercontent.com/15910173/60542435-3f64fb00-9d14-11e9-96d5-f34e2a00c0a6.png)
