### PR TITLE
Fixes/duplicate installed apps

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -271,6 +271,11 @@ Then, wam core will manage the packages' installation and avoid duplicate instal
 
 
 - *app_settings.py* contains application specific settings and is loaded at start of django server at the end of *settings.py*. This file may include additional database connections, loading of config files needed for the application, etc.
+
+
+.. warning:: Avoid using config variables for packages in your app as it may override or get overridden by package config of other app!
+
+
 - *labels.cfg* (uses configobj_) supports easy adding of labels to templates via templatetags (see :ref:`label_tags`)
 
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -261,11 +261,11 @@ Requirements:
 Additional setups:
 
 - *settings.py* can setup additional parameters for projects *settings.py*.
-If your app requires the use of java packages, you should list them in the settings.py of your app (not the settings.py file form wam core) in the following way
+If your app requires the use of additional packages, you should list them in the settings.py of your app (not the settings.py file form wam core) in the following way
 
 .. code:: python
 
-    INSTALLED_APP = ['js_package1', 'js_package2']
+    INSTALLED_APP = ['package1', 'package2']
 
 Then, wam core will manage the packages' installation and avoid duplicate installations between the different apps.
 

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -260,7 +260,16 @@ Requirements:
 
 Additional setups:
 
-- *settings.py* can setup additional parameters for projects *settings.py*
+- *settings.py* can setup additional parameters for projects *settings.py*.
+If your app requires the use of java packages, you should list them in the settings.py of your app (not the settings.py file form wam core) in the following way
+
+.. code:: python
+
+    INSTALLED_APP = ['js_package1', 'js_package2']
+
+Then, wam core will manage the packages' installation and avoid duplicate installations between the different apps.
+
+
 - *app_settings.py* contains application specific settings and is loaded at start of django server at the end of *settings.py*. This file may include additional database connections, loading of config files needed for the application, etc.
 - *labels.cfg* (uses configobj_) supports easy adding of labels to templates via templatetags (see :ref:`label_tags`)
 

--- a/wam/settings.py
+++ b/wam/settings.py
@@ -191,7 +191,10 @@ for app in WAM_APPS:
         for setting in dir(settings):
             if setting == setting.upper():
                 if setting in locals() and isinstance(locals()[setting], list):
-                    locals()[setting] += getattr(settings, setting)
+                    attr_list = getattr(settings, setting)
+                    for attr in attr_list:
+                        if attr not in locals()[setting]:
+                            locals()[setting].append(attr)
                 else:
                     locals()[setting] = getattr(settings, setting)
 


### PR DESCRIPTION
Every list entry from app-specific settings.py is checked for duplicates while importing into original wam.settings.
As before, additional packages can easily be added to wam.settings by:

```
# app/settings.py

INSTALLED_APPS = ['package']
```