### PR TITLE
Enable markdownx extension support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Here is a template for new release sections
 ## [Unreleased]
 
 ### Added
+- enable support for markdownx extensions #83
 
 ### Changed
 

--- a/utils/widgets.py
+++ b/utils/widgets.py
@@ -12,6 +12,12 @@ from django.forms.renderers import get_default_renderer
 
 from wam.settings import BASE_DIR
 
+# import markdownx extensions from settings if available
+try:
+    from wam.settings import MARKDOWNX_MARKDOWN_EXTENSIONS
+except ImportError:
+    MARKDOWNX_MARKDOWN_EXTENSIONS = []
+
 
 class CustomWidget(ABC):
     template_name: str = None
@@ -77,7 +83,9 @@ class InfoButton(CustomWidget):
             prepended by "info_". By default, a counter is used which results
             in ids "info_0", "info_1" etc.
         """
-        self.text = markdown(text) if is_markdown else text
+        self.text = markdown(text,
+                             extensions=MARKDOWNX_MARKDOWN_EXTENSIONS)\
+            if is_markdown else text
         self.tooltip = tooltip
         self.ionicon_type = ionicon_type
         self.ionicon_size = ionicon_size

--- a/wam/settings.py
+++ b/wam/settings.py
@@ -209,3 +209,8 @@ for app in WAM_APPS:
 WAM_EXCHANGE_ACCOUNT = config['WAM']['WAM_EXCHANGE_ACCOUNT']
 WAM_EXCHANGE_EMAIL = config['WAM']['WAM_EXCHANGE_EMAIL']
 WAM_EXCHANGE_PW = config['WAM']['WAM_EXCHANGE_PW']
+
+# Extensions for markdownx
+MARKDOWNX_MARKDOWN_EXTENSIONS = [
+    'markdown.extensions.extra'
+]


### PR DESCRIPTION
Solves #83 and enables extension [`markdown.extensions.extra`](https://python-markdown.github.io/extensions/extra/).