### PR TITLE
Translate feedback form into English

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ Here is a template for new release sections
 - apps' icon size increased on landing page #89
 - install docs extended: docker
 - update README.md
+- language in feedback form changed to EN #93
 
 ## [0.1.2] 2019-07-04
 

--- a/templates/feedback.html
+++ b/templates/feedback.html
@@ -6,18 +6,18 @@
   <main>
     <section class="grid-x align-center l-bg-color--light hp-features">
       <div class="cell medium-8 large-6">
-        <h1><i class='icon ion-chatbubbles icon--large'></i> Ihr Feedback</h1>
+        <h1><i class='icon ion-chatbubbles icon--large'></i> Your Feedback</h1>
         <p><strong>App: <a href="../" class="u-padding-top--l u-padding-bt--l">{{ app_name }}</a></strong></p>
         {% if intro_text %}
           <p>{{ intro_text }}</p>
         {% else %}
-          <p>Hier können Sie uns eine Rückmeldung zur App geben, wir freuen uns über Ihre Nachricht!</p>
+          <p>Here you can give us your feedback about the app, we are looking forward to your message!</p>
         {% endif %}
 
         <form method="post">
           {% csrf_token %}
           {{ form }}
-          <button class="btn btn-cta" type="submit" style="float: right;">Abschicken</button>
+          <button class="btn btn-cta" type="submit" style="float: right;">Send</button>
         </form>
       </div>
     </section>

--- a/utils/forms.py
+++ b/utils/forms.py
@@ -5,15 +5,15 @@ class FeedbackForm(forms.Form):
     """Input form for feedback page"""
     from_name = forms.CharField(required=False,
                                 max_length=100,
-                                label='Ihr Name (optional)')
+                                label='Your Name (optional)')
     from_email = forms.EmailField(required=False,
-                                  label='Ihre E-Mail-Adresse (optional)')
+                                  label='Email Address (optional)')
     subject = forms.CharField(required=True,
                               max_length=100,
-                              label='Betreff')
+                              label='Subject')
     message = forms.CharField(widget=forms.Textarea,
                               required=True,
-                              label='Ihr Feedback')
+                              label='Your Feedback')
 
     def submit(self):
         pass


### PR DESCRIPTION
To keep it more universal, the Feedback form is translated into English (esp. useful for UNECE event).

(we can add more general i18n support #76 to utils module later)