### PR TITLE
App url is build on backend not frontend

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -37,12 +37,7 @@
                     <img src="{% static app.icon %}" alt="{{app.name}}" class="hp_wam_img_small">
                   </div>
                   <div class="u-text--center u-margin--m">
-                    {% if app.url_arg %}
-                      {% url app.url path=app.url_arg as url %}
-                    {% else %}
-                      {% url app.url as url %}
-                    {% endif %}
-                    <a href="{{url}}" class="btn btn-cta" title="{{app.name}}">
+                    <a href="{{app.url}}" class="btn btn-cta" title="{{app.name}}">
                       {{app.category.goto}}
                       <i class ="icon ion-chevron-right icon--small"></i>
                     </a>

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -1,11 +1,27 @@
 from enum import Enum
-from collections import namedtuple
+from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 
 
-AppInfo = namedtuple(
-    "AppInfo", ["category", "name", "url", "closed", "icon", "url_arg"],
-)
-AppInfo.__new__.__defaults__ = (False, None, None)
+class AppInfo:
+    def __init__(self, category, name, url, closed=False, icon=None, url_arg=None):
+        self.category = category
+        self.name = name
+        self.__url = url
+        self.closed = closed
+        self.icon = icon
+        self.__url_arg = url_arg
+
+    @property
+    def url(self):
+        try:
+            if self.__url_arg is None:
+                url = reverse(self.__url)
+            else:
+                url = reverse(self.__url, kwargs={"path": self.__url_arg})
+        except NoReverseMatch:
+            url = self.__url
+        return url
 
 
 class AppCategory(Enum):

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -4,7 +4,33 @@ from django.urls.exceptions import NoReverseMatch
 
 
 class AppInfo:
-    def __init__(self, category, name, url, closed=False, icon=None, url_arg=None):
+    """App infos are used on WAM landing page"""
+
+    def __init__(
+        self,
+        category: str,
+        name: str,
+        url: str,
+        closed: bool = False,
+        icon: str = None,
+        url_arg: str = None,
+    ):
+        """
+
+        Parameters
+        ----------
+        category:
+            Must be one of available app categories (AppCategory).
+            App is placed in corresponding category section.
+        name:
+            Is displayed on landing page
+        url: Either namespace url to django app, or fix url (to extern page)
+        closed:
+            If closed is active, a lock symbol is shown.
+            (Access restrictions have to be set up by the app itself)
+        icon: Icon to be shown on landing page
+        url_arg: Optional path argument to (namespace) url - relict? unused?
+        """
         self.category = category
         self.name = name
         self.__url = url
@@ -14,6 +40,12 @@ class AppInfo:
 
     @property
     def url(self):
+        """
+        Returns app url for landing page
+
+        First reverse namespace url is tried (with url args if given), if this fails,
+        url will be returned "as is".
+        """
         try:
             if self.__url_arg is None:
                 url = reverse(self.__url)


### PR DESCRIPTION
Fixes #105
Custom urls could not be rendered otherwise. Now, at first, reverse url match is tried, otherwise url is simply put in place.